### PR TITLE
Add included directories backup filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Local Backup
 
+[中文说明](README.zh.md)
+
 ![GitHub](https://img.shields.io/github/license/cgcel/obsidian-local-backup)
 ![Github all releases](https://img.shields.io/github/downloads/cgcel/obsidian-local-backup/total.svg)
 ![GitLab latest release](https://badgen.net/github/release/cgcel/obsidian-local-backup)
@@ -18,6 +20,7 @@ Automatically creates a local backup of the vault.
 - Retry after failures
 - Create specific file
 - Ignore folders and files using wildcards
+- Back up only selected folders and files using wildcards
 
 ## How to use
 
@@ -32,8 +35,18 @@ Automatically creates a local backup of the vault.
 
 1. Setup the output path depends on your computer platform.
 2. Setup the Windows and Unix output path while you using these two platforms.
+3. `Included directories` and `Excluded directories` both accept comma-separated values and support the same wildcard matching rules.
+4. If `Included directories` is empty, the whole vault is backed up before exclusions are applied.
+5. If `Included directories` is set, only matching folders and files are backed up, then `Excluded directories` can be used to remove matches from that result.
 
 > *If you turn on interval backups, it is recommended to set a reasonable bakcup frequency, e.g. >=10min, this plugin costs CPU resources and Disk I/O resources, backup frequently might cause lagging.*
+
+##### Include and exclude examples
+
+- Back up only the Obsidian config folder: set `Included directories` to `.obsidian`
+- Back up only selected content: set `Included directories` to `.obsidian, Templates, *.canvas`
+- Back up the whole vault except some paths: leave `Included directories` empty and set `Excluded directories` to `.git, .trash, node_modules, *.mp4`
+- Combine both filters: set `Included directories` to `.obsidian, Templates` and `Excluded directories` to `workspace.json`
 
 #### File Archiver Settings (Optional)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,122 @@
+# Local Backup
+
+[English](README.md)
+
+![GitHub](https://img.shields.io/github/license/cgcel/obsidian-local-backup)
+![Github all releases](https://img.shields.io/github/downloads/cgcel/obsidian-local-backup/total.svg)
+![GitLab latest release](https://badgen.net/github/release/cgcel/obsidian-local-backup)
+[![CodeQL](https://github.com/cgcel/obsidian-local-backup/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/cgcel/obsidian-local-backup/actions/workflows/codeql.yml)
+
+自动为 Obsidian 仓库创建本地备份。
+
+## 功能特性
+
+- 启动时备份
+- 退出时备份
+- 可配置备份保留周期
+- 可自定义输出路径
+- 支持定时备份
+- 支持调用外部压缩器进行备份（7-Zip、WinRAR、Bandizip）
+- 失败后自动重试
+- 支持创建指定名称的备份文件
+- 支持通过通配符忽略目录和文件
+- 支持通过通配符只备份指定目录和文件
+
+## 使用方法
+
+### 插件设置
+
+#### 常规设置
+
+![general-settings-1](screenshot/general-settings-1.png)
+![general-settings-2](screenshot/general-settings-2.png)
+
+##### 提示
+
+1. 请根据你的操作系统设置输出路径。
+2. 如果你会在 Windows 和 Unix 系统之间切换使用，请分别配置这两个输出路径。
+3. `Included directories` 和 `Excluded directories` 都使用逗号分隔，并支持相同的通配符匹配规则。
+4. 如果 `Included directories` 为空，则会先备份整个仓库，再应用排除规则。
+5. 如果设置了 `Included directories`，则只会备份命中的目录和文件，然后再用 `Excluded directories` 从结果中继续剔除。
+
+> *如果你开启定时备份，建议设置一个合理的频率，例如不少于 10 分钟。这个插件会消耗 CPU 和磁盘 I/O 资源，过于频繁的备份可能导致卡顿。*
+
+##### 包含与排除示例
+
+- 只备份 Obsidian 配置目录：将 `Included directories` 设置为 `.obsidian`
+- 只备份部分内容：将 `Included directories` 设置为 `.obsidian, Templates, *.canvas`
+- 备份整个仓库但排除部分路径：将 `Included directories` 留空，并将 `Excluded directories` 设置为 `.git, .trash, node_modules, *.mp4`
+- 组合使用包含与排除：将 `Included directories` 设置为 `.obsidian, Templates`，并将 `Excluded directories` 设置为 `workspace.json`
+
+#### 文件压缩设置（可选）
+
+![file-archiver-settings](screenshot/file-archiver-settings.png)
+
+##### 提示
+
+1. （实验性功能）如果你的仓库很大，备份时 Obsidian 会卡住，可以尝试在设置页面启用这个实验性功能。
+
+> *如果你的仓库体积较大，建议在设置页面启用 `External file archiver backup`，也就是最新版本中的实验性功能，然后继续完成压缩器相关设置。*
+
+### 运行本地备份命令
+
+#### 命令面板
+
+使用 `Ctrl + P` 打开命令面板。
+
+![run-command](screenshot/run-command.png)
+
+#### 创建特定备份
+
+如上面的命令面板截图所示，如果你想长期保留某个备份文件，可以创建一个指定名称的备份。通过这个命令创建的文件不会被插件自动删除。但你需要确保它和 `File name` 设置不同。例如：`File name` 为 `dev-Backup-%Y_%m_%d-%H_%M_%S`，那么你手动输入的特定文件名就不要使用同样的格式。
+
+#### 侧边栏图标
+
+点击侧边栏图标。
+
+![sidebar-icon](screenshot/sidebar-icon.png)
+
+## 安装
+
+### 从插件市场安装
+
+- 在 Obsidian Community Plugins 中搜索 `Local Backup` 并安装
+- 启用 `Local Backup`
+- 按照 [使用方法](#使用方法) 配置 `Local Backup`
+- 应用设置或重启 Obsidian
+- 开始使用
+
+### 手动安装插件
+
+- 将 `main.js`、`styles.css`、`manifest.json` 复制到你的仓库目录 `VaultFolder/.obsidian/plugins/your-plugin-id/`
+- 打开 Obsidian 并启用 `Local Backup`
+- 按照上面的 [从插件市场安装](#从插件市场安装) 指引继续操作
+
+## 参与贡献
+
+### 构建
+
+**欢迎代码贡献，直接向 master 分支发起 PR 即可 :)**
+
+- 克隆这个仓库
+- 确保你的 NodeJS 至少是 v16（`node --version`）
+- 运行 `npm i` 或 `yarn` 安装依赖
+- 运行 `npm run dev` 启动监听模式编译
+- 运行 `npm run build` 构建 `./build` 中的 `main.js`
+
+## 参考
+
+- [adm-zip](https://github.com/cthackers/adm-zip)
+- [7-Zip](https://www.7-zip.org/)
+- [WinRAR](https://www.win-rar.com/)
+- [Bandizip](https://www.bandisoft.com/)
+
+## 赞助这个项目
+
+如果这个插件帮你节省了时间，也欢迎请作者喝杯咖啡。
+
+https://paypal.me/gris0297
+
+## 许可证
+
+**Obsidian Local Backup** 基于 MIT 协议发布。更多信息请参阅 [LICENSE](https://github.com/cgcel/obsidian-local-backup/blob/master/LICENSE)。

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ interface LocalBackupPluginSettings {
 	showConsoleLog: boolean;
 	showNotifications: boolean;
 	excludedDirectoriesValue: string;
+	includedDirectoriesValue: string;
 	customizedArguments: string;
 }
 
@@ -55,6 +56,7 @@ const DEFAULT_SETTINGS: LocalBackupPluginSettings = {
 	showConsoleLog: false,
 	showNotifications: true,
 	excludedDirectoriesValue: "",
+	includedDirectoriesValue: "",
 	customizedArguments: "",
 };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,6 +36,7 @@ interface LocalBackupPluginSettings {
 	archiverWinPathValue: string;
 	archiverUnixPathValue: string;
 	excludedDirectoriesValue: string; // Added for excluded directories
+	includedDirectoriesValue: string;
 }
 
 export class LocalBackupSettingTab extends PluginSettingTab {
@@ -214,6 +215,21 @@ export class LocalBackupSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.excludedDirectoriesValue)
 					.onChange(async (value: string) => {
 						this.plugin.settings.excludedDirectoriesValue = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("Included directories")
+			.setDesc(
+				"Specify directories or files to include in backup. Use comma-separated list with wildcards (e.g., .obsidian, Templates, *.canvas). Leave empty to back up the whole vault before exclusions are applied."
+			)
+			.addText((text: TextComponent) =>
+				text
+					.setPlaceholder(".obsidian")
+					.setValue(this.plugin.settings.includedDirectoriesValue)
+					.onChange(async (value: string) => {
+						this.plugin.settings.includedDirectoriesValue = value;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,21 +187,27 @@ export class LocalBackupUtils {
 		// const AdmZip = require("adm-zip");
 		const zip = new AdmZip();
 
-		// Get excluded patterns from settings
-		const excludedPatterns = this.plugin.settings.excludedDirectoriesValue
-			.split(",")
-			.map((pattern) => pattern.trim())
-			.filter((pattern) => pattern.length > 0);
+		const excludedPatterns = this.parsePatternList(
+			this.plugin.settings.excludedDirectoriesValue
+		);
+		const includedPatterns = this.parsePatternList(
+			this.plugin.settings.includedDirectoriesValue
+		);
 
 		if (
-			excludedPatterns.length > 0 &&
+			(includedPatterns.length > 0 || excludedPatterns.length > 0) &&
 			this.plugin.settings.showConsoleLog
 		) {
-			this.log(`Excluding patterns: ${excludedPatterns.join(", ")}`, "log");
+			if (includedPatterns.length > 0) {
+				this.log(`Including patterns: ${includedPatterns.join(", ")}`, "log");
+			}
+			if (excludedPatterns.length > 0) {
+				this.log(`Excluding patterns: ${excludedPatterns.join(", ")}`, "log");
+			}
 		}
 
-		// If no exclusions, add the entire folder
-		if (excludedPatterns.length === 0) {
+		// If no filters, add the entire folder
+		if (excludedPatterns.length === 0 && includedPatterns.length === 0) {
 			zip.addLocalFolder(vaultPath);
 		} else {
 			// Add files and folders selectively
@@ -218,23 +224,18 @@ export class LocalBackupUtils {
 				for (const entry of entries) {
 					const fullPath = path.join(dirPath, entry);
 					const entryRelativePath = path.join(relativePath, entry);
+					const stats = fs.statSync(fullPath);
 
-					// Check if this path should be excluded
-					if (
-						this.shouldExcludePath(
-							entryRelativePath,
-							excludedPatterns
-						)
-					) {
+					if (this.shouldExcludePath(entryRelativePath, excludedPatterns)) {
 						continue;
 					}
 
-					const stats = fs.statSync(fullPath);
-
 					if (stats.isDirectory()) {
-						// Recursively add subdirectories
+						// Keep walking the tree so nested included files can still be found.
 						addFilesRecursively(fullPath, entryRelativePath);
-					} else {
+					} else if (
+						this.shouldIncludePath(entryRelativePath, includedPatterns)
+					) {
 						// Add file to zip
 						zip.addLocalFile(fullPath, relativePath);
 					}
@@ -264,14 +265,21 @@ export class LocalBackupUtils {
 		backupFilePath: string,
 		customizedArguments: string
 	) {
-		// Get excluded patterns from settings
-		const excludedPatterns = this.plugin.settings.excludedDirectoriesValue
-			.split(",")
-			.map((pattern) => pattern.trim())
-			.filter((pattern) => pattern.length > 0);
+		const excludedPatterns = this.parsePatternList(
+			this.plugin.settings.excludedDirectoriesValue
+		);
+		const includedPatterns = this.parsePatternList(
+			this.plugin.settings.includedDirectoriesValue
+		);
+		const includedEntries = this.collectIncludedEntries(
+			vaultPath,
+			includedPatterns,
+			excludedPatterns
+		);
 
 		// Prepare exclusion parameters for different archivers
 		let exclusionParams = "";
+		let inputSources = `"${vaultPath}"`;
 
 		if (excludedPatterns.length > 0) {
 				this.log(`Excluding patterns for ${archiverType}: ${excludedPatterns.join(
@@ -301,13 +309,25 @@ export class LocalBackupUtils {
 			}
 		}
 
+		if (includedPatterns.length > 0) {
+			this.log(`Including patterns for ${archiverType}: ${includedPatterns.join(", ")}`, "log");
+
+			if (includedEntries.length === 0) {
+				throw new Error(
+					"No files or directories matched the Included directories setting."
+				);
+			}
+
+			inputSources = includedEntries.map((entry) => `"${entry}"`).join(" ");
+		}
+
 		switch (archiverType) {
 			case "sevenZip":
 				const sevenZipPromise = new Promise<void>((resolve, reject) => {
-					const command = `"${archiverPath}" a "${backupFilePath}" "${vaultPath}" ${exclusionParams} ${customizedArguments}`;
+					const command = `"${archiverPath}" a "${backupFilePath}" ${inputSources} ${exclusionParams} ${customizedArguments}`;
 						this.log(`command: ${command}`, "log");
 
-					exec(command, (error, stdout, stderr) => {
+					exec(command, { cwd: includedPatterns.length > 0 ? vaultPath : undefined }, (error, stdout, stderr) => {
 						if (error) {
 							this.log(`Failed to create file by 7-Zip: ${error.message}`, "error");
 							reject(error);
@@ -321,10 +341,10 @@ export class LocalBackupUtils {
 
 			case "winRAR":
 				const winRARPromise = new Promise<void>((resolve, reject) => {
-					const command = `"${archiverPath}" a -ep1 -rh ${exclusionParams} ${customizedArguments} "${backupFilePath}" "${vaultPath}\\*"`;
+					const command = `"${archiverPath}" a -ep1 -rh ${exclusionParams} ${customizedArguments} "${backupFilePath}" ${includedPatterns.length > 0 ? inputSources : `"${vaultPath}\\*"`}`;
 						this.log(`command: ${command}`, "log");
 
-					exec(command, (error, stdout, stderr) => {
+					exec(command, { cwd: includedPatterns.length > 0 ? vaultPath : undefined }, (error, stdout, stderr) => {
 						if (error) {
 							this.log(`Failed to create file by WinRAR: ${error.message}`, "error");
 							reject(error);
@@ -338,10 +358,10 @@ export class LocalBackupUtils {
 
 			case "bandizip":
 				const bandizipPromise = new Promise<void>((resolve, reject) => {
-					const command = `"${archiverPath}" c ${exclusionParams} ${customizedArguments} "${backupFilePath}" "${vaultPath}"`;
+					const command = `"${archiverPath}" c ${exclusionParams} ${customizedArguments} "${backupFilePath}" ${inputSources}`;
 						this.log(`command: ${command}`, "log");
 
-					exec(command, (error, stdout, stderr) => {
+					exec(command, { cwd: includedPatterns.length > 0 ? vaultPath : undefined }, (error, stdout, stderr) => {
 						if (error) {
 							this.log(`Failed to create file by Bandizip: ${error.message}`, "error");
 							reject(error);
@@ -358,6 +378,60 @@ export class LocalBackupUtils {
 		}
 	}
 
+	parsePatternList(value: string): string[] {
+		return value
+			.split(",")
+			.map((pattern) => pattern.trim())
+			.filter((pattern) => pattern.length > 0);
+	}
+
+	collectIncludedEntries(
+		vaultPath: string,
+		includedPatterns: string[],
+		excludedPatterns: string[]
+	): string[] {
+		if (includedPatterns.length === 0) {
+			return [];
+		}
+
+		const collectedEntries = new Set<string>();
+
+		const walk = (dirPath: string, relativePath: string = "") => {
+			const entries = fs.readdirSync(dirPath);
+
+			for (const entry of entries) {
+				const fullPath = path.join(dirPath, entry);
+				const entryRelativePath = path.join(relativePath, entry);
+				const stats = fs.statSync(fullPath);
+
+				if (this.shouldExcludePath(entryRelativePath, excludedPatterns)) {
+					continue;
+				}
+
+				if (
+					stats.isDirectory() &&
+					this.shouldIncludePath(entryRelativePath, includedPatterns)
+				) {
+					collectedEntries.add(entryRelativePath.replace(/\\/g, "/"));
+					continue;
+				}
+
+				if (stats.isDirectory()) {
+					walk(fullPath, entryRelativePath);
+					continue;
+				}
+
+				if (this.shouldIncludePath(entryRelativePath, includedPatterns)) {
+					collectedEntries.add(entryRelativePath.replace(/\\/g, "/"));
+				}
+			}
+		};
+
+		walk(vaultPath);
+
+		return Array.from(collectedEntries);
+	}
+
 	/**
 	 * Check if a path should be excluded based on the wildcards
 	 * @param filePath The path to check
@@ -369,9 +443,25 @@ export class LocalBackupUtils {
 			return false;
 		}
 
+		return this.matchesPatterns(filePath, excludedPatterns, "Excluding");
+	}
+
+	shouldIncludePath(filePath: string, includedPatterns: string[]): boolean {
+		if (!includedPatterns || includedPatterns.length === 0) {
+			return true;
+		}
+
+		return this.matchesPatterns(filePath, includedPatterns, "Including");
+	}
+
+	matchesPatterns(
+		filePath: string,
+		patterns: string[],
+		actionLabel: string
+	): boolean {
 		const normalizedPath = filePath.replace(/\\/g, "/");
 
-		for (const pattern of excludedPatterns) {
+		for (const pattern of patterns) {
 			if (!pattern.trim()) continue;
 
 			// Convert glob pattern to regex
@@ -385,7 +475,7 @@ export class LocalBackupUtils {
 
 			if (regex.test(normalizedPath)) {
 					this.log(
-						`Excluding path: ${filePath} (matched pattern: ${pattern})`, "log"
+						`${actionLabel} path: ${filePath} (matched pattern: ${pattern})`, "log"
 					);
 				return true;
 			}


### PR DESCRIPTION
base repository: velviagris/obsidian-local-backup
base branch: master
head repository: raozhiyong11/obsidian-local-backup
compare branch: feature/included-directories


## Summary

This PR adds an `Included directories` setting to support backing up only selected folders or files.

## Changes

- add `includedDirectoriesValue` to plugin settings
- add `Included directories` input in settings UI
- apply include filtering to built-in `adm-zip` backup flow
- apply include filtering to external archiver backup flow
- keep wildcard and comma-separated matching behavior consistent with `Excluded directories`
- document the new setting in README
- add Chinese documentation in `README.zh.md`

## Example

To back up only Obsidian configuration files:

- `Included directories`: `.obsidian`
- `Excluded directories`: leave empty
